### PR TITLE
Fix group_by to_struct panic on invalid type

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/concat.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/concat.rs
@@ -49,10 +49,9 @@ pub(super) fn convert_diagonal_concat(
         }
         *node = IRBuilder::new(*node, expr_arena, lp_arena)
             // Add the missing columns
-            .with_columns(columns_to_add, Default::default())
+            .with_columns(columns_to_add, Default::default())?
             // Now, reorder to match schema.
-            .project_simple(total_schema.iter_names().map(|v| v.as_str()))
-            .unwrap()
+            .project_simple(total_schema.iter_names().map(|v| v.as_str()))?
             .node();
     }
 
@@ -103,7 +102,7 @@ pub(super) fn convert_st_union(
                     &mut ExprToIRContext::new_with_opt_eager(expr_arena, &input_schema, opt_flags),
                 )?;
                 let lp = IRBuilder::new(*input, expr_arena, lp_arena)
-                    .with_columns(expr, Default::default())
+                    .with_columns(expr, Default::default())?
                     .build();
 
                 let node = lp_arena.add(lp);

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -1140,7 +1140,7 @@ fn resolve_group_by(
     utils::validate_expressions(&keys, expr_arena, input_schema, "group by")?;
     utils::validate_expressions(&aggs, expr_arena, input_schema, "group by")?;
 
-    let mut aggs_schema = expr_irs_to_schema(&aggs, input_schema, expr_arena);
+    let mut aggs_schema = expr_irs_to_schema(&aggs, input_schema, expr_arena)?;
 
     // Make sure aggregation columns do not contain duplicates
     if aggs_schema.len() < aggs.len() {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
@@ -43,7 +43,7 @@ pub(super) fn process_group_by(
         &keys,
         lp_arena.get(input).schema(lp_arena).as_ref(),
         expr_arena,
-    );
+    )?;
 
     let mut new_acc_predicates = PlHashMap::with_capacity(acc_predicates.len());
 

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/group_by.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/group_by.rs
@@ -30,7 +30,7 @@ pub(super) fn process_group_by(
         let input = lp_arena.add(lp);
 
         let builder = IRBuilder::new(input, expr_arena, lp_arena);
-        Ok(proj_pd.finish_node_simple_projection(&ctx.acc_projections, builder))
+        proj_pd.finish_node_simple_projection(&ctx.acc_projections, builder)
     } else {
         let has_pushed_down = ctx.has_pushed_down();
 
@@ -86,6 +86,6 @@ pub(super) fn process_group_by(
             maintain_order,
             options,
         );
-        Ok(builder.build())
+        Ok(builder?.build())
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/hstack.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/hstack.rs
@@ -61,7 +61,7 @@ pub(super) fn process_hstack(
     proj_pd.pushdown_and_assign(input, ctx, lp_arena, expr_arena)?;
 
     let lp = IRBuilder::new(input, expr_arena, lp_arena)
-        .with_columns(exprs, options)
+        .with_columns(exprs, options)?
         .build();
     Ok(lp)
 }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
@@ -499,6 +499,6 @@ fn resolve_join_suffixes(
             .project_simple(projections.iter().map(|e| e.output_name().clone()))?
             .build()
     } else {
-        builder.project(projections, Default::default()).build()
+        builder.project(projections, Default::default())?.build()
     })
 }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -248,31 +248,30 @@ impl ProjectionPushDown {
         let lp = lp.with_inputs(new_inputs);
 
         let builder = IRBuilder::from_lp(lp, expr_arena, lp_arena);
-        Ok(self.finish_node_simple_projection(&ctx.acc_projections, builder))
+        self.finish_node_simple_projection(&ctx.acc_projections, builder)
     }
 
     fn finish_node_simple_projection(
         &mut self,
         local_projections: &[ColumnNode],
         builder: IRBuilder,
-    ) -> IR {
+    ) -> PolarsResult<IR> {
         if !local_projections.is_empty() {
-            builder
-                .project_simple_nodes(local_projections.iter().map(|node| node.0))
-                .unwrap()
-                .build()
+            Ok(builder
+                .project_simple_nodes(local_projections.iter().map(|node| node.0))?
+                .build())
         } else {
-            builder.build()
+            Ok(builder.build())
         }
     }
 
-    fn finish_node(&mut self, local_projections: Vec<ExprIR>, builder: IRBuilder) -> IR {
+    fn finish_node(&mut self, local_projections: Vec<ExprIR>, builder: IRBuilder) -> PolarsResult<IR> {
         if !local_projections.is_empty() {
-            builder
-                .project(local_projections, Default::default())
-                .build()
+            Ok(builder
+                .project(local_projections, Default::default())?
+                .build())
         } else {
-            builder.build()
+            Ok(builder.build())
         }
     }
 

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/projection.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/projection.rs
@@ -150,7 +150,7 @@ pub(super) fn process_projection(
             .project_simple_nodes(local_projection.into_iter().map(|e| e.node()))?
             .build()
     } else {
-        proj_pd.finish_node(local_projection, builder)
+        proj_pd.finish_node(local_projection, builder)?
     };
 
     Ok(lp)

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -249,9 +249,9 @@ pub(crate) fn aexprs_to_schema<I: IntoIterator<Item = K>, K: Into<Node>>(
     expr: I,
     schema: &Schema,
     arena: &Arena<AExpr>,
-) -> Schema {
+) -> PolarsResult<Schema> {
     expr.into_iter()
-        .map(|node| arena.get(node.into()).to_field(schema, arena).unwrap())
+        .map(|node| arena.get(node.into()).to_field(schema, arena))
         .collect()
 }
 
@@ -259,18 +259,18 @@ pub(crate) fn expr_irs_to_schema<I: IntoIterator<Item = K>, K: AsRef<ExprIR>>(
     expr: I,
     schema: &Schema,
     arena: &Arena<AExpr>,
-) -> Schema {
+) -> PolarsResult<Schema> {
     expr.into_iter()
         .map(|e| {
             let e = e.as_ref();
-            let mut field = e.field(schema, arena).expect("should be resolved");
+            let mut field = e.field(schema, arena)?;
 
             // TODO! (can this be removed?)
             if let Some(name) = e.get_alias() {
                 field.name = name.clone()
             }
             field.dtype = field.dtype.materialize_unknown(true).unwrap();
-            field
+            Ok(field)
         })
         .collect()
 }


### PR DESCRIPTION
Propagate schema inference errors as `PolarsResult` to prevent panics in `group_by` and other contexts.

Previously, operations like `arr.to_struct()` or `name.prefix_fields()` applied to incompatible data types within a `group_by` context would cause a panic (e.g., `expect("should be resolved")`). This change modifies schema inference functions to return a `PolarsResult` and propagates errors, ensuring that such type mismatches result in a proper `InvalidOperationError` instead of a crash.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff15dbbd-14bd-4b14-8998-7f5704284732">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff15dbbd-14bd-4b14-8998-7f5704284732">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

